### PR TITLE
Правильно проверяется ответ пользователя и сохраняется в его профиль

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ new -> waiting-questions -> with-question -> end
 docker pull mongo
 
 // Старт монги
-docker run -d -p 27017:27017 mongo
+docker run -d -p 27017:27017 -v ~/mongo_data:/data/db mongo
 ```
 
 ## Redis

--- a/src/bot/game/pipe.spec.js
+++ b/src/bot/game/pipe.spec.js
@@ -129,7 +129,9 @@ describe("Пайпы для обработки пользователя по р�
           expect(pipe().gamer.status).toEqual(WITH_QUESTIONS_STATUS);
         });
         it("Добавляет к пользователю вопрос", () => {
-          expect(pipe().gamer.answers[0]).toEqual(attachedQuestion);
+          expect(pipe().gamer.answers[0].questionnaireId).toEqual(
+            attachedQuestion._id.toString()
+          );
         });
         it("Генерирует сообщение", () => {
           expect(pipe().message.msg).toEqual(jasmine.any(String));

--- a/src/bot/game/pipes.js
+++ b/src/bot/game/pipes.js
@@ -1,6 +1,7 @@
 const R = require("ramda");
 
 const { WITH_QUESTIONS_STATUS } = require("../user");
+const { makeGamerAnswer } = require("../user/answers");
 
 module.exports = {
   processNoQuestionnaireForGamer,
@@ -33,12 +34,15 @@ function processHasQuestionnaireForGamer(questionnaire = {}) {
       return Object.assign({}, payload, {
         gamer: Object.assign(gamer, {
           status: WITH_QUESTIONS_STATUS,
-          answers: gamer.answers.concat(questionnaire)
+          answers: gamer.answers.concat(makeGamerAnswer(questionnaire))
         }),
         message: {
           id: gamer.telegramId,
           msg: questionnaire.title,
-          replies: questionnaire.options
+          replies: questionnaire.options.map(v => ({
+            id: questionnaire._id,
+            value: v
+          }))
         }
       });
     }

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -52,17 +52,18 @@ bot.onText(/\/start/, msg => {
 setInterval(() => {
   processWaitingUsers()
     .then(messages =>
-      messages.map(({ id, msg, replies }) =>
+      messages.map(({ id, msg, replies }) => {
+        // TODO: пока не удалось сериализовать объект и передать его в кнопку. Поэтому вот так странно создаем callback_data
+        const keyboard = replies.map((reply, i) => [
+          { text: reply.value, callback_data: `${reply.id}--${i}` }
+        ]);
         bot.sendMessage(id, renderQuestion(msg), {
           parse_mode: "HTML",
           reply_markup: {
-            inline_keyboard: replies.map((text, i) => [
-              { text, callback_data: i }
-            ]),
-            one_time_keyboard: true
+            inline_keyboard: keyboard
           }
-        })
-      )
+        });
+      })
     )
     .catch(console.log);
 }, 2000);

--- a/src/bot/user/answers.js
+++ b/src/bot/user/answers.js
@@ -1,0 +1,16 @@
+const R = require("ramda");
+
+module.exports = {
+  makeGamerAnswer
+};
+
+function makeGamerAnswer(questionnaire = {}, value, isCorrect) {
+  return {
+    questionnaireId: R.compose(R.toString, R.propOr({}, "_id"))(questionnaire),
+    category: questionnaire.category,
+    answeredAt: new Date(),
+    answered: value != undefined && isCorrect != undefined,
+    value,
+    isCorrect
+  };
+}

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -63,13 +63,16 @@ function updateUser(user) {
   return save(user);
 }
 
-function updateUserAnswer(answer, updatedFields) {
+// @param принимает объект результата makeGamerAnswer
+function updateUserAnswer(newAnswer) {
   return updateArrayValue(
     User,
-    { "answers._id": answer._id },
+    { "answers.questionnaireId": newAnswer.questionnaireId },
     {
-      "answers.$.answer.isCorrect": updatedFields.isCorrect,
-      "answers.$.answer.answeredAt": updatedFields.answeredAt
+      "answers.$.isCorrect": newAnswer.isCorrect,
+      "answers.$.value": newAnswer.value,
+      "answers.$.answeredAt": newAnswer.answeredAt,
+      "answers.$.answered": newAnswer.answered
     }
   );
 }

--- a/src/database/models/question.js
+++ b/src/database/models/question.js
@@ -1,7 +1,6 @@
 const mongoose = require("mongoose");
 
 const questionSchema = new mongoose.Schema({
-  id: Number,
   title: String,
   category: String,
   options: [String],

--- a/test-helpers/questionnaires.js
+++ b/test-helpers/questionnaires.js
@@ -23,7 +23,7 @@ function generateQuestionnaires(count = 0, categories = []) {
 function generateQuestionnaire(options) {
   return Object.assign(
     {
-      id: Date.now(),
+      _id: Date.now(),
       title: faker.lorem.sentence(),
       category: 0,
       options: ["incorrect", "correct", "incorrect", "incorrect"],


### PR DESCRIPTION
Inline кнопка отправляет id вопроса. По нему находим в профайле пользователя запись и в ней сохраняем корректность.
Корректность проверяется не по "значению", а по "порядковому номеру ответа", как в старой реализации.
Также изменена структура answer в профайле. Теперь там совсем нет "вопроса", его нужно отдельно выбирать по `id` из базы. 
#37 решает, но не очень красиво. Нужно вынести формирование клавиатуры отдельно. И попробовать сериализовать объект в `callback_data`

Полностью решает #32 , теперь просто нет старой клавиатуры.